### PR TITLE
fix/add_vendor_association_to_displays

### DIFF
--- a/app/controllers/spree/api/v2/display_products_controller.rb
+++ b/app/controllers/spree/api/v2/display_products_controller.rb
@@ -5,9 +5,9 @@ module Spree
     module V2
       class DisplayProductsController < Spree::Api::V2::ResourceController
         include Spree::Api::V2::CollectionOptionsHelpers
+        before_action :require_spree_current_user
         before_action :load_display
-        before_action :require_spree_current_user, only: [:create, :update, :destroy]
-
+        before_action :require_display_access
 
         def index
           render_serialized_payload { serialize_resource(paginated_collection) }
@@ -67,6 +67,12 @@ module Spree
 
         def display_product_params
           params.require(:display_product).permit(:product_id, :qr_code_url, :video_url)
+        end
+
+        def require_display_access
+          return if @display.vendor.users.include?(spree_current_user)
+
+          render_error_payload('You do not have permission to access this display', 401)
         end
       end
     end

--- a/app/controllers/spree/api/v2/displays_controller.rb
+++ b/app/controllers/spree/api/v2/displays_controller.rb
@@ -2,11 +2,12 @@ module Spree
   module Api
     module V2
       class DisplaysController < ::Spree::Api::V2::ResourceController
+        before_action :require_spree_current_user
+        before_action :load_vendor, :require_vendor_access
         before_action :load_display, only: [:show, :update, :destroy]
-        before_action :require_spree_current_user, only: [:create, :update, :destroy]
 
         def index
-          @displays = Spree::Display.order(active: :desc)
+          @displays = @vendor.displays.order(active: :desc)
           
           render_serialized_payload { serialize_resource(@displays) }
         end
@@ -16,7 +17,7 @@ module Spree
         end
 
         def create
-          @display = Spree::Display.new(display_params)
+          @display = @vendor.displays.new(display_params)
 
           if @display.save
             render_serialized_payload { serialize_resource(@display) }
@@ -26,8 +27,6 @@ module Spree
         end
 
         def update
-          display = Spree::Display.find(params[:id])
-          
           if @display.update(display_params)
             render_serialized_payload { serialize_resource(@display) }
           else
@@ -36,9 +35,7 @@ module Spree
         end
 
         def destroy
-          display = Spree::Display.find(params[:id])
-
-          if display.destroy
+          if @display.destroy
             render_serialized_payload { serialize_resource(display) }
           else
             render_error_payload(display.errors)
@@ -48,7 +45,7 @@ module Spree
         private
 
         def load_display
-          @display = Spree::Display.find(params[:id])
+          @display = @vendor.displays.find(params[:id])
         end
 
         def display_params
@@ -65,6 +62,16 @@ module Spree
 
         def collection_serializer
           Spree::Api::V2::DisplaySerializer
+        end
+
+        def load_vendor
+          @vendor ||= Spree::Vendor.find(params[:vendor_id])
+        end
+
+        def require_vendor_access
+          return if @vendor.users.include?(spree_current_user)
+
+          render_error_payload('You do not have permission to access this vendor', 401)
         end
       end
     end

--- a/app/models/spree/display.rb
+++ b/app/models/spree/display.rb
@@ -2,6 +2,7 @@ module Spree
   class Display < ActiveRecord::Base
     has_many :display_products
     has_many :products, through: :display_product, class_name: 'Spree::Product'
+    belongs_to :vendor
 
     before_validation :set_default_screen_size
 

--- a/app/models/spree/display_product.rb
+++ b/app/models/spree/display_product.rb
@@ -3,6 +3,7 @@
 module Spree
   class DisplayProduct < ActiveRecord::Base
     require 'rqrcode'
+    include Spree::Core::Engine.routes.url_helpers
 
     belongs_to :display
     belongs_to :product
@@ -38,9 +39,14 @@ module Spree
 
 
     def generate_qr_code
-      return if qr_code_image.attached? || ENV['STOREFRONT_URL'].blank?
+      return if qr_code_image.attached?
 
-      product_storefront_url = "#{ENV['STOREFRONT_URL']}/products/#{product.slug}?display_id=#{display.id}"
+      product_storefront_url = if ENV['STOREFRONT_URL']
+                                 "#{ENV['STOREFRONT_URL']}/products/#{product.slug}?display_id=#{display.id}"
+                               else
+                                 product_url(product.slug, host: Rails.application.routes.default_url_options[:host], display_id: display.id)
+                               end
+
       qrcode = RQRCode::QRCode.new(product_storefront_url)
 
       png = qrcode.as_png(size: 300)

--- a/app/models/spree/vendor_decorator.rb
+++ b/app/models/spree/vendor_decorator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Spree
+  module VendorDecorator
+    def self.prepended(base)
+      base.has_many :displays, class_name: 'Spree::Display'
+    end
+  end
+end
+
+Spree::Vendor.prepend Spree::VendorDecorator

--- a/app/serializers/spree/api/v2/display_serializer.rb
+++ b/app/serializers/spree/api/v2/display_serializer.rb
@@ -2,7 +2,7 @@ module Spree
   module Api
     module V2
       class DisplaySerializer < BaseSerializer
-        attributes :id, :name, :screen_size, :orientation, :display_type, :products_array, :active
+        attributes :id, :name, :screen_size, :orientation, :vendor_id, :display_type, :products_array, :active
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,13 @@
 Spree::Core::Engine.add_routes do
   namespace :api, defaults: { format: 'json' } do
     namespace :v2 do
-      resources :displays, only: [:index, :show, :create, :update, :destroy] do
+      resources :vendors, only: [] do
+        resources :displays, only: [:index, :show, :create, :update, :destroy]
+      end
+
+      resources :displays, only: [] do
         resources :display_products, only: [:index, :create, :destroy]
       end
     end
-  end 
+  end
 end

--- a/db/migrate/20240904140637_add_vendor_to_spree_display.rb
+++ b/db/migrate/20240904140637_add_vendor_to_spree_display.rb
@@ -1,0 +1,9 @@
+class AddVendorToSpreeDisplay < ActiveRecord::Migration[7.1]
+  def self.up
+    add_column :spree_displays, :vendor_id, :integer
+  end
+
+  def self.down
+    remove_column :spree_displays, :vendor_id
+  end
+end


### PR DESCRIPTION
TASKS:
- Add vendor association to the displays
- Add default route to display product qr in case of missing storefront url in env file

`The display APIs have been moved to /api/v2/vendors/:vendor_id/displays`